### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci-secrets-scan.yml
+++ b/.github/workflows/ci-secrets-scan.yml
@@ -7,6 +7,8 @@
 # https://opensource.org/licenses/MIT
 
 name: Scan secrets for CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/atsushifx/template-for-starter/security/code-scanning/2](https://github.com/atsushifx/template-for-starter/security/code-scanning/2)

To fix this problem, add a `permissions` block to restrict the job’s (or workflow’s) `GITHUB_TOKEN` permissions to only what is required. For this workflow, scanning secrets and uploading artifacts, the job does not need write access to repository contents, only `contents: read`. The artifact upload action does not require special repository permissions. The safest way is to add `permissions: contents: read` either at the top level (applies to all jobs) or to the individual job (`gitleaks`). Since only one job exists here, the best practice is to add it at the top just below the `name:` field for global coverage.

This change should be made near the top of the file, directly under the workflow `name:` on line 9 to line 10, so that it applies to all jobs in the workflow. No other changes or additional imports are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
