### PR TITLE
config(rulesets): シークレットスキャンをBetterleaksへ移行しコード品質チェックを更新

### DIFF
--- a/.github/rulesets/template-ruleset-protect-default.json
+++ b/.github/rulesets/template-ruleset-protect-default.json
@@ -44,7 +44,7 @@
         "do_not_enforce_on_create": false,
         "required_status_checks": [
           {
-            "context": "Gitleaks Secret Scan / Scan secrets with Gitleaks",
+            "context": "Betterleaks Secret Scan / Betterleaks Secret Scan",
             "integration_id": 15368
           }
         ]
@@ -66,13 +66,9 @@
       "type": "required_linear_history"
     },
     {
-      "type": "copilot_code_review_analysis_tools",
+      "type": "code_quality",
       "parameters": {
-        "tools": [
-          {
-            "name": "CodeQL"
-          }
-        ]
+        "severity": "warnings"
       }
     }
   ],


### PR DESCRIPTION
## Overview

**Summary**
デフォルトブランチ保護ルールセットの必須チェックを Betterleaks 移行およびコード品質設定に合わせて更新する。

**Background / Motivation**
#57 で Gitleaks から Betterleaks へのシークレットスキャンツール移行が完了したため、ルールセットの必須ステータスチェックを新しいチェック名に更新する必要がある。あわせて、コードレビュー分析ツールの設定を `copilot_code_review_analysis_tools`（CodeQL個別指定）から `code_quality`（severity ベースの一括設定）へ変更し、保守性を向上させる。

## Changes

### Core Changes

- `.github/rulesets/template-ruleset-protect-default.json`
  - `required_status_checks` のコンテキストを `Gitleaks Secret Scan / Scan secrets with Gitleaks` から `Betterleaks Secret Scan / Betterleaks Secret Scan` へ変更し、`integration_id: 15368` を追加
  - `copilot_code_review_analysis_tools`（CodeQL名称指定）を `code_quality`（`severity: "warnings"` ベース）へ置き換え

### Test Updates

なし（設定ファイルのみの変更）

### Removed

- `copilot_code_review_analysis_tools` ルールとその `tools` 配列（CodeQL個別指定）

## Change Type (optional)

Select all that apply:

- [ ] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [x] Configuration
- [ ] CI/CD
- [ ] Other

## Related Issues

Closes #11
Related to #57

## Checklist

Please confirm the following (if applicable):

- [x] Formatting and lint checks pass (e.g. `dprint check`, `pnpm lint`)
- [x] Tests pass (if test suite exists)
- [ ] Documentation updated (for user-facing changes)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Shared types and utilities are imported from common modules, not inlined in implementation files

## Additional Notes

- Betterleaks の `integration_id` は `15368` を使用（既存ワークフロー定義と一致）
- `code_quality` ルールに `severity: "warnings"` を指定することで、ツールを個別に列挙せず一括管理できる
