### PR TITLE
config(claude): add settings.json with allow/deny permissions

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,37 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(git status:*)",
+      "Bash(git log:*)",
+      "Bash(git show:*)",
+      "Bash(git diff:*)",
+      "Bash(git rev-parse:*)",
+      "Bash(git branch:*)",
+      "Bash(git remote:*)",
+      "Bash(git config --get:*)",
+      "Bash(git ls-files:*)",
+      "Bash(gh pr view:*)",
+      "Bash(gh pr list:*)",
+      "Bash(gh issue view:*)",
+      "Bash(gh issue list:*)",
+      "Bash(gh repo view:*)",
+      "Bash(node:*)",
+      "Bash(pnpm:*)",
+      "Read(docs/**)"
+    ],
+    "deny": [
+      "Bash(git commit:*)",
+      "Bash(git push:*)",
+      "Bash(git reset:*)",
+      "Bash(git restore:*)",
+      "Bash(git clean:*)",
+      "Bash(git rebase:*)",
+      "Bash(git merge:*)",
+      "Bash(git checkout:*)",
+      "Bash(git switch:*)",
+      "Bash(git stash:*)"
+    ],
+    "defaultMode": "plan",
+    "skipAutoPermissionPrompt": false
+  }
+}

--- a/templates/.claude/settings.json
+++ b/templates/.claude/settings.json
@@ -1,0 +1,37 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(git status:*)",
+      "Bash(git log:*)",
+      "Bash(git show:*)",
+      "Bash(git diff:*)",
+      "Bash(git rev-parse:*)",
+      "Bash(git branch:*)",
+      "Bash(git remote:*)",
+      "Bash(git config --get:*)",
+      "Bash(git ls-files:*)",
+      "Bash(gh pr view:*)",
+      "Bash(gh pr list:*)",
+      "Bash(gh issue view:*)",
+      "Bash(gh issue list:*)",
+      "Bash(gh repo view:*)",
+      "Bash(node:*)",
+      "Bash(pnpm:*)",
+      "Read(docs/**)"
+    ],
+    "deny": [
+      "Bash(git commit:*)",
+      "Bash(git push:*)",
+      "Bash(git reset:*)",
+      "Bash(git restore:*)",
+      "Bash(git clean:*)",
+      "Bash(git rebase:*)",
+      "Bash(git merge:*)",
+      "Bash(git checkout:*)",
+      "Bash(git switch:*)",
+      "Bash(git stash:*)"
+    ],
+    "defaultMode": "plan",
+    "skipAutoPermissionPrompt": false
+  }
+}

--- a/templates/.gitignore
+++ b/templates/.gitignore
@@ -57,6 +57,9 @@ $~*
 # claude code setting
 .claude/*
 
+# settings
+!.claude/**/settings.json
+
 # agents can tracking
 !.claude/agents/
 !.claude/agents/**


### PR DESCRIPTION
## Overview

**Summary**
Adds `.claude/settings.json` to enforce explicit allow/deny permissions for Claude Code operations.

**Background / Motivation**
Claude Code が自律的に破壊的な Git 操作（commit / push / reset 等）を実行するリスクを排除するため、操作権限を明示的に制御する設定ファイルを導入する。
`defaultMode: "plan"` により、デフォルトで計画モードで動作するよう制限する。
同設定をプロジェクトテンプレートにも反映し、新規プロジェクトがこのセキュリティポリシーを初期状態から継承できるようにする。

## Changes

### Core Changes

- `.claude/settings.json` — 新規作成。git/gh の読み取り系コマンドと `node` / `pnpm` を allow、`git commit` / `git push` / `git reset` / `git restore` / `git clean` / `git rebase` / `git merge` / `git checkout` / `git switch` / `git stash` を deny、`defaultMode: "plan"` を設定
- `templates/.claude/settings.json` — 同一内容で新規作成（新規プロジェクトへのテンプレート反映）
- `templates/.gitignore` — `.claude/*` 除外ルールに `!.claude/**/settings.json` 例外を追加し、settings.json をトラッキング対象に含める

### Test Updates

N/A

### Removed

N/A

## Change Type (optional)

Select all that apply:

- [ ] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [x] Configuration
- [ ] CI/CD
- [ ] Other

## Related Issues

> N/A

## Checklist

Please confirm the following (if applicable):

- [x] Formatting and lint checks pass (e.g. `dprint check`, `pnpm lint`)
- [ ] Tests pass (if test suite exists)
- [ ] Documentation updated (for user-facing changes)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Shared types and utilities are imported from common modules, not inlined in implementation files

## Additional Notes

`templates/.gitignore` への変更により、新規プロジェクト作成時に `settings.json` が自動的に git トラッキング対象となる。既存プロジェクトで同様の設定を行う場合は、`.gitignore` の例外ルールを手動で追加する必要がある。
