### PR TITLE
ci(templates): upgrade ci-platform to v0.2.1 and fix copyright year

### DIFF
--- a/templates/.github/workflows/ci-scan-secrets.yml
+++ b/templates/.github/workflows/ci-scan-secrets.yml
@@ -1,7 +1,7 @@
 # src: ./.github/workflows/ci-scan-secrets.yml
 # @(#) : Caller workflow for secret scanning in .github repository
 #
-# Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
+# Copyright (c) 2025- atsushifx <https://github.com/atsushifx>
 #
 # This software is released under the MIT License.
 # https://opensource.org/licenses/MIT
@@ -24,8 +24,8 @@ on:
   workflow_dispatch:
 
 jobs:
-  scan-gitleaks:
-    name: Gitleaks Secret Scan
+  scan-betterleaks:
+    name: Betterleaks Secret Scan
     permissions:
       contents: read
-    uses: aglabo/.github/.github/workflows/ci-common-scan-gitleaks.yml@r1.1.2
+    uses: aglabo/ci-platform/.github/workflows/ci-scan-betterleaks.yml@2ac45debcb9c2902597abda02bcce3e6ff0121f0 # v0.2.1

--- a/templates/.github/workflows/ci-workflows-qa.yml
+++ b/templates/.github/workflows/ci-workflows-qa.yml
@@ -1,7 +1,7 @@
 # src: ./.github/workflows/ci-workflows-qa.yml
 # @(#) : Caller workflow for GitHub Actions workflow QA in .github repository
 #
-# Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
+# Copyright (c) 2025- atsushifx <https://github.com/atsushifx>
 #
 # This software is released under the MIT License.
 # https://opensource.org/licenses/MIT
@@ -32,10 +32,10 @@ jobs:
     name: Actionlint
     permissions:
       contents: read
-    uses: aglabo/.github/.github/workflows/ci-common-lint-actionlint.yml@r1.1.2
+    uses: aglabo/ci-platform/.github/workflows/ci-qa-actionlint.yml@2ac45debcb9c2902597abda02bcce3e6ff0121f0 # v0.2.1
 
   ghalint:
     name: Ghalint
     permissions:
       contents: read
-    uses: aglabo/.github/.github/workflows/ci-common-lint-ghalint.yml@r1.1.2
+    uses: aglabo/ci-platform/.github/workflows/ci-qa-ghalint.yml@2ac45debcb9c2902597abda02bcce3e6ff0121f0 # v0.2.1


### PR DESCRIPTION
## Overview

**Summary**
Migrate template workflows to ci-platform v0.2.1 and correct copyright year from 2026 to 2025

**Background / Motivation**
テンプレートのワークフローファイルが古いアクションパスを参照しており、copyright year も誤っていた。
`ci-scan-secrets` は `gitleaks` から `betterleaks` へ切り替え、`ci-workflows-qa` の `actionlint`/`ghalint` は ci-platform v0.2.1 の `uses` パスに更新する必要があった。copyright year も実際のリリース年に合わせて `2026-` → `2025-` に修正する。

## Changes

### Core Changes

- `templates/.github/workflows/ci-scan-secrets.yml`: replaced `gitleaks` job name and `uses` path with `betterleaks` referencing `ci-platform` v0.2.1; corrected copyright year from `2026-` to `2025-`
- `templates/.github/workflows/ci-workflows-qa.yml`: updated `actionlint` and `ghalint` `uses` paths to `ci-platform` v0.2.1; corrected copyright year from `2026-` to `2025-`

### Test Updates

N/A — workflow template changes; no unit tests applicable.

### Removed

N/A — no files removed.

## Change Type (optional)

Select all that apply:

- [ ] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [x] Configuration
- [x] CI/CD
- [ ] Other

## Related Issues

> N/A

## Checklist

Please confirm the following (if applicable):

- [ ] Formatting and lint checks pass (e.g. `dprint check`, `pnpm lint`)
- [ ] Tests pass (if test suite exists)
- [ ] Documentation updated (for user-facing changes)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Shared types and utilities are imported from common modules, not inlined in implementation files

## Additional Notes

このPRはテンプレートワークフローファイルのみを更新する。各プロジェクトは更新されたテンプレートをコピーすることで変更を取り込む必要がある。
